### PR TITLE
Fix flake8 warnings W292 and W293 by removing trailing whitespace and…

### DIFF
--- a/service/routes.py
+++ b/service/routes.py
@@ -130,4 +130,5 @@ def delete_accounts(account_id):
         account.delete()
 
     return "", status.HTTP_204_NO_CONTENT
-    
+
+# dahir: Removed blank line at the end of the file to fix flake8 W391 warning and trailing whitespace for W293


### PR DESCRIPTION
… ensuring no blank line at end of file